### PR TITLE
feat: implement layout standalone transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,13 @@ and reloading your project, you can instance the node `GuiTransition` in your sc
 See the properties in the next section to learn how to configure it properly, but pay attention to the required properties:
 
 - `Layout`: The main layout node. It will be hidden and shown accordingly. Should be the topmost node of the current GUI layout, usually the scene root. If you don't set the `Layout ID` property, this node's name will be assumed as the layout ID. **Always required!**
-- `Controls`: An array of nodes that will be animated in sequence. **Required if `Group` is not set!**
-- `Group`: A node with children controls to be animated in sequence. **Required if `Controls` is not set!**
+- `Controls`: An array of nodes that will be animated in sequence.
+- `Group`: A node with children controls to be animated in sequence.
+
+**Notes:**
+- If you don't set both `Controls` and `Group`, the `Layout` itself will be animated.
+In this case, the `Delay` property will not be used.
+- If you set both `Controls` and `Group`, only `Controls` will be animated and `Group` will be ignored.
 
 ### Triggering Transitions
 After setting up its properties, the layout should at least be shown with a transition at startup.
@@ -91,6 +96,21 @@ increasing the player's strength multiple times.
 Simple GUI Transitions is exactly that: simple to set up and use.
 Check the detailed documentation below to learn more.
 
+### Known Limitations
+- No support for changing properties at runtime. This means that you can't
+add controls to `Controls` and `Group` at runtime, and changing other properties
+will have unknown side effects.
+Maybe the support for this will be added in the future,
+but this plugin was designed for static menus and interfaces, after all.
+- No support for slide animations on containers.
+The slide animations will work on visible controls
+(such as buttons and other interactable nodes)
+and the layout (if it is using anchors).
+This is due to the fact that the slide transition on controls work through a shader,
+and it can't animate the children of a container.
+The layout transition, in the other hand, works through anchor tweening,
+so make sure the layout is using anchors to be sized on the screen.
+
 ## Global Settings
 The default transition settings can be set on `Project > Project Settings > GUI Transitions > Config` (you may need to enable `Advanced Settings` to see this section).
 Those settings will be applied on top of any `Default` property on the node `GuiTransition`. This is useful to increase or decrease the speed of transitions on the whole project, for example. See each property description below.
@@ -138,18 +158,16 @@ Optional ID of layout to trigger changes on the singleton `GuiTransitions` (at m
 If empty, will be assumed as the `Layout` node name.
 
 #### Layout
-The main layout node. It will be hidden and shown accordingly. Should be the topmost node of the current layout. **Required!**
+**Required!** The main layout node. It will be hidden and shown accordingly. Should be the topmost node of the current layout. If your don't set `Controls` or `Group`, the `Layout` itself will be animated.
 
 #### Controls
 Array of individual nodes to be animated.
 The order will be taken in account to apply the animation `Delay`.
-**If empty, a `Group` must be set.**
 
 #### Group
 A node with children controls to be animated in sequence.
 The order will be taken in account to apply the animation `Delay`.
 Example: a `HBoxContainer` or `VBoxContainer` with several buttons as children will allow to animate all buttons one by one.
-**If not set, `Controls` must be selected.**
 
 #### Center Pivot
 When `Animation Enter` or `Animation Leave` is one of the scale animations, it will center the control's `pivot_offset` property.

--- a/addons/simple-gui-transitions/example/layout_1.tscn
+++ b/addons/simple-gui-transitions/example/layout_1.tscn
@@ -16,7 +16,6 @@ script = ExtResource("1")
 
 [node name="GuiTransition" type="Node" parent="."]
 script = ExtResource("2")
-fade_layout = 0
 animation_enter = 0
 animation_leave = 1
 layout = NodePath("..")

--- a/addons/simple-gui-transitions/example/layout_1.tscn
+++ b/addons/simple-gui-transitions/example/layout_1.tscn
@@ -16,10 +16,10 @@ script = ExtResource("1")
 
 [node name="GuiTransition" type="Node" parent="."]
 script = ExtResource("2")
+fade_layout = 0
 animation_enter = 0
-animation_leave = 0
+animation_leave = 1
 layout = NodePath("..")
-group = NodePath("../HBoxContainer/VBoxContainer")
 
 [node name="HBoxContainer" type="HBoxContainer" parent="."]
 layout_mode = 0

--- a/addons/simple-gui-transitions/plugin.cfg
+++ b/addons/simple-gui-transitions/plugin.cfg
@@ -3,5 +3,5 @@
 name="Simple GUI Transitions"
 description="Simple GUI transitions to swap menus elegantly."
 author="Joel Gomes (joelgomes1994, murikistudio)"
-version="0.3.0"
+version="0.4.0"
 script="plugin.gd"

--- a/addons/simple-gui-transitions/transition.gd
+++ b/addons/simple-gui-transitions/transition.gd
@@ -52,10 +52,13 @@ class NodeInfo extends RefCounted:
 	var initial_position: Vector2
 	var initial_scale: Vector2
 	var initial_mouse_filter: int
+	var initial_anchor_x: Vector2
+	var initial_anchor_y: Vector2
 	var delay: float
 	var duration: float
 	var center_pivot: bool
 	var tween: Tween
+	var layout_only: bool
 
 	func _init(
 		_node: Control,
@@ -64,7 +67,8 @@ class NodeInfo extends RefCounted:
 		_animation_enter: int,
 		_animation_leave: int,
 		_auto_start: bool,
-		_center_pivot: bool
+		_center_pivot: bool,
+		_layout_only: bool
 	) -> void:
 		node = _node
 		name = node.name
@@ -74,6 +78,10 @@ class NodeInfo extends RefCounted:
 		delay = _delay
 		duration = _duration
 		center_pivot = _center_pivot
+		layout_only = _layout_only
+
+		initial_anchor_x = Vector2(node.anchor_left, node.anchor_right)
+		initial_anchor_y = Vector2(node.anchor_top, node.anchor_bottom)
 
 		var shader_animations := [
 			Anim.SLIDE_LEFT,
@@ -82,7 +90,7 @@ class NodeInfo extends RefCounted:
 			Anim.SLIDE_DOWN
 		]
 
-		if _animation_enter in shader_animations or _animation_leave in shader_animations:
+		if not _layout_only and (_animation_enter in shader_animations or _animation_leave in shader_animations):
 			node.material = MaterialTransform.duplicate()
 
 		if _auto_start:
@@ -131,6 +139,22 @@ class NodeInfo extends RefCounted:
 				offset.y = -view_size.y * 2.0
 			Anim.SLIDE_DOWN:
 				offset.y = view_size.y * 2.0
+
+		return offset
+
+	# Get the out-of-screen anchor factor of node according to the animation type.
+	func get_target_anchor(animation: int) -> Vector2:
+		var offset := Vector2.ZERO
+
+		match animation:
+			Anim.SLIDE_LEFT:
+				offset = Vector2(-1.0, 0.0)
+			Anim.SLIDE_RIGHT:
+				offset = Vector2(1.0, 2.0)
+			Anim.SLIDE_UP:
+				offset = Vector2(-1.0, 0.0)
+			Anim.SLIDE_DOWN:
+				offset = Vector2(1.0, 2.0)
 
 		return offset
 
@@ -261,6 +285,9 @@ var _is_shown := false
 
 ## Parsed transition status enum value.
 var _status: int = Status.OK
+
+## If apply transitions only to layout (no group or controls set).
+var _layout_only := false
 
 ## Main control affected by this transition.
 @onready var _layout: Control = get_node(layout) if layout else null
@@ -504,15 +531,11 @@ func _hide(id := "", function = null):
 # Abstraction methods
 ## Returns if it's possible to perform transition.
 func _transition_valid() -> bool:
-	var controls_source_valid := bool(controls.size() or _group)
+	if not _layout:
+		push_warning("A valid layout must be set on GuiTransition: %s" % get_path())
+		return false
 
-	if not layout:
-		push_warning("A layout must be set on GuiTransition: %s" % self.get_path())
-
-	if not controls_source_valid:
-		push_warning("A list of controls or a group container must be set on GuiTransition: %s" % self.get_path())
-
-	return controls_source_valid and layout
+	return true
 
 
 ## Performs the slide in transition.
@@ -523,15 +546,40 @@ func _slide_in(node_info: NodeInfo):
 	if node_info.delay:
 		node_info.tween.tween_interval(node_info.delay)
 
-	node_info.tween\
-		.set_trans(_transition)\
-		.set_ease(_ease)\
-		.tween_method(
-			node_info.set_position,
-			node_info.get_target_position(animation_enter),
-			node_info.initial_position,
-			node_info.duration
-		)
+	if _layout_only:
+		var anchor_x := "anchor_left" if animation_enter in [Anim.SLIDE_LEFT, Anim.SLIDE_RIGHT] else "anchor_top"
+		var anchor_y := "anchor_right" if animation_enter in [Anim.SLIDE_LEFT, Anim.SLIDE_RIGHT] else "anchor_bottom"
+		var target_anchor := node_info.get_target_anchor(animation_enter)
+		node_info.node.set(anchor_x, target_anchor.x)
+		node_info.node.set(anchor_y, target_anchor.y)
+
+		node_info.tween\
+			.set_trans(_transition)\
+			.set_ease(_ease)\
+			.tween_property(
+				node_info.node,
+				anchor_x, 0.0,
+				node_info.duration
+			)
+		node_info.tween\
+			.parallel()\
+			.set_trans(_transition)\
+			.set_ease(_ease)\
+			.tween_property(
+				node_info.node,
+				anchor_y, 1.0,
+				node_info.duration
+			)
+	else:
+		node_info.tween\
+			.set_trans(_transition)\
+			.set_ease(_ease)\
+			.tween_method(
+				node_info.set_position,
+				node_info.get_target_position(animation_enter),
+				node_info.initial_position,
+				node_info.duration
+			)
 
 	node_info.unset_clickable()
 	await node_info.tween.finished
@@ -547,15 +595,40 @@ func _slide_out(node_info: NodeInfo):
 	if node_info.delay:
 		node_info.tween.tween_interval(node_info.delay)
 
-	node_info.tween\
-		.set_trans(_transition)\
-		.set_ease(_ease)\
-		.tween_method(
-			node_info.set_position,
-			node_info.initial_position,
-			node_info.get_target_position(animation_leave),
-			node_info.duration
-		)
+	if _layout_only:
+		var anchor_x := "anchor_left" if animation_leave in [Anim.SLIDE_LEFT, Anim.SLIDE_RIGHT] else "anchor_top"
+		var anchor_y := "anchor_right" if animation_leave in [Anim.SLIDE_LEFT, Anim.SLIDE_RIGHT] else "anchor_bottom"
+		var target_anchor := node_info.get_target_anchor(animation_leave)
+		node_info.node.set(anchor_x, 0.0)
+		node_info.node.set(anchor_y, 1.0)
+
+		node_info.tween\
+			.set_trans(_transition)\
+			.set_ease(_ease)\
+			.tween_property(
+				node_info.node,
+				anchor_x, target_anchor.x,
+				node_info.duration
+			)
+		node_info.tween\
+			.parallel()\
+			.set_trans(_transition)\
+			.set_ease(_ease)\
+				.tween_property(
+				node_info.node,
+				anchor_y, target_anchor.y,
+				node_info.duration
+			)
+	else:
+		node_info.tween\
+			.set_trans(_transition)\
+			.set_ease(_ease)\
+			.tween_method(
+				node_info.set_position,
+				node_info.initial_position,
+				node_info.get_target_position(animation_leave),
+				node_info.duration
+			)
 
 	node_info.unset_clickable()
 	await node_info.tween.finished
@@ -643,7 +716,7 @@ func _scale_out(node_info: NodeInfo):
 
 ## Gradually fade in the whole layout along with individual transitions.
 func _fade_in_layout() -> void:
-	if not fade_layout:
+	if not fade_layout or _layout_only:
 		_tween.tween_interval(duration)
 		return
 
@@ -652,7 +725,7 @@ func _fade_in_layout() -> void:
 
 ## Gradually fade out the whole layout along with individual transitions.
 func _fade_out_layout() -> void:
-	if not fade_layout:
+	if not fade_layout or _layout_only:
 		_tween.tween_interval(duration)
 		return
 
@@ -680,13 +753,16 @@ func _get_nodes_from_containers() -> Array[Control]:
 		if node:
 			_controls.push_back(node)
 
-	var nodes := _controls if _controls.size() else _group.get_children()
+	var nodes: Array = _controls if _controls.size() \
+		else _group.get_children() if _group \
+		else [_layout]
+	_layout_only = _layout and not _controls.size() and not _group
 	var filtered_nodes: Array[Control] = []
 
 	for n in nodes:
 		var node: Node = n
 
-		if node and node.is_class("Control") and not node.get_class() == "Control":
+		if node and node.is_class("Control") and (not node.get_class() == "Control" or _layout_only):
 			filtered_nodes.push_back(node)
 
 	return filtered_nodes
@@ -728,7 +804,8 @@ func _get_node_infos() -> void:
 			animation_enter,
 			animation_leave,
 			auto_start,
-			center_pivot
+			center_pivot,
+			_layout_only
 		))
 
 

--- a/addons/simple-gui-transitions/transition.gd
+++ b/addons/simple-gui-transitions/transition.gd
@@ -740,7 +740,7 @@ func _scale_out(node_info: NodeInfo):
 
 ## Gradually fade in the whole layout along with individual transitions.
 func _fade_in_layout() -> void:
-	if not fade_layout or _layout_only:
+	if not fade_layout or _layout_only and animation_enter == Anim.FADE:
 		_tween.tween_interval(duration)
 		return
 
@@ -749,7 +749,7 @@ func _fade_in_layout() -> void:
 
 ## Gradually fade out the whole layout along with individual transitions.
 func _fade_out_layout() -> void:
-	if not fade_layout or _layout_only:
+	if not fade_layout or _layout_only and animation_leave == Anim.FADE:
 		_tween.tween_interval(duration)
 		return
 

--- a/addons/simple-gui-transitions/transition.gd
+++ b/addons/simple-gui-transitions/transition.gd
@@ -255,6 +255,8 @@ const DEBUG := false
 
 ## The main layout node. It will be hidden and shown accordingly.
 ## Should be the topmost node of the current layout.
+## If your don't set [code]Controls[/code] or [code]Group[/code],
+## the [code]Layout[/code] itself will be animated.
 ## [b][color=red]Required![/color][/b]
 @export var layout: NodePath
 


### PR DESCRIPTION
Changes suggested by @Melon-The-Dev on [Discord](https://discord.gg/X5mthm2q8q).

- [feat: implement layout standalone transitions](https://github.com/murikistudio/simple-gui-transitions/commit/ed78ba2e5cde757ec7e93dcc09fa95c190e615af)
    - use anchors instead of shaders for layout transitions
    - fix combinations of scale, slide and fade enter/leave transitions
- [fix: fade layout when transition is not fade](https://github.com/murikistudio/simple-gui-transitions/commit/3501f68ea708fc80f54f63a3c01e54f0224531ab)
- [doc: document the new standalone layout transition](https://github.com/murikistudio/simple-gui-transitions/commit/15f9160f07cf0fe3635c99bf568b696325e4c207)
    - add limitations to readme
- [release: set plugin version to 0.4.0](https://github.com/murikistudio/simple-gui-transitions/commit/40f9b456da0d7c94048af43d2a7b7387608cddc3)