### PR TITLE
Add new singleton signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,11 +197,23 @@ Ease curve of the animations. Same as `Tween.EaseType`.
 The singleton `GuiTransitions` allows to trigger the transitions globally and swap GUI layouts.
 
 ### Signals
+#### show_started
+Emitted when a layout is about to be shown.
+
 #### show_completed
-The signal `show_completed` is emited after a layout has been shown.
+Emitted after a layout has been shown.
+
+#### hide_started
+Emited when a layout is about to be hidden.
 
 #### hide_completed
-The signal `hide_completed` is emited after a layout has been hidden.
+Emitted after a layout has been hidden.
+
+#### transition_started
+Emmited when a layout is about to be shown or hidden.
+
+#### transition_completed
+Emited after a layout has been shown or hidden.
 
 ### Public Methods
 **Note**: Optional arguments in the methods below are suffixed with `?` (e.g. `function?`).
@@ -209,7 +221,7 @@ The signal `hide_completed` is emited after a layout has been hidden.
 #### go_to(id: String, function?: Callable)
 The method `go_to` hides the current layout and shows the layout with the given `id`.
 If `function` (optional) is passed in, the `function` will be executed halfway through.
-Both signals `hide_completed` and `show_completed` are emited accordingly.
+Both signals `hide_completed` and `show_completed` are emitted accordingly.
 
 #### update(function?: Callable)
 The method `update` hides and shows the current layout.

--- a/addons/simple-gui-transitions/singleton.gd
+++ b/addons/simple-gui-transitions/singleton.gd
@@ -3,11 +3,23 @@ extends Node
 
 
 # Signals
+## Emited when a layout is about to be shown.
+signal show_started
+
 ## Emited after a layout has been shown.
 signal show_completed
 
+## Emited when a layout is about to be hidden.
+signal hide_started
+
 ## Emited after a layout has been hidden.
 signal hide_completed
+
+## Emmited when a layout is about to be shown or hidden.
+signal transition_started
+
+## Emited after a layout has been shown or hidden.
+signal transition_completed
 
 
 # Variables

--- a/addons/simple-gui-transitions/transition.gd
+++ b/addons/simple-gui-transitions/transition.gd
@@ -101,7 +101,7 @@ class NodeInfo extends RefCounted:
 	func init_tween() -> void:
 		if not is_instance_valid(node):
 			return
-			
+
 		if tween and tween.is_valid():
 			tween.kill()
 
@@ -522,12 +522,17 @@ func _show(id := ""):
 			else:
 				_slide_in(node_info)
 
+		GuiTransitions.transition_started.emit()
+		GuiTransitions.show_started.emit()
+
 		if _tween and _tween.is_valid():
 			await _tween.finished
+
 		_is_shown = true
 		_status = Status.OK
 
 		if GuiTransitions.is_shown(layout_id):
+			GuiTransitions.transition_completed.emit()
 			GuiTransitions.show_completed.emit()
 
 
@@ -547,6 +552,9 @@ func _hide(id := "", function = null):
 			else:
 				_slide_out(node_info)
 
+		GuiTransitions.transition_started.emit()
+		GuiTransitions.hide_started.emit()
+
 		if _tween and _tween.is_valid():
 			await _tween.finished
 
@@ -558,6 +566,7 @@ func _hide(id := "", function = null):
 		_status = Status.OK
 
 		if GuiTransitions.is_hidden(layout_id):
+			GuiTransitions.transition_completed.emit()
 			GuiTransitions.hide_completed.emit()
 
 


### PR DESCRIPTION
Add useful signals to run logic when a layout is about to be shown and similar cases.

- Add extra signals on singleton
    - `show_started`: Emitted when a layout is about to be shown.
    - `hide_started`: Emited when a layout is about to be hidden.
    - `transition_started`: Emmited when a layout is about to be shown or hidden.
    - `transition_completed`: Emited after a layout has been shown or hidden.
- Document new signals on readme