### PR TITLE
Only include the addons folder when downloading release

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,7 @@
 # Normalize EOL for all files that Git considers text files.
 * text=auto eol=lf
+
+# Only include the addons folder when downloading from the Asset Library.
+/**        export-ignore
+/addons    !export-ignore
+/addons/** !export-ignore


### PR DESCRIPTION
Closes #17 

* Only include the addons folder when downloading from the Asset Library